### PR TITLE
handle empty result as an error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,7 @@ class I18NextLocizeBackend {
         err = 'failed parsing ' + url + ' to json';
       }
       if (err) return callback(err, false);
+      if (0 === Object.keys(ret).length) return callback('translation is blank', false);
       callback(null, ret);
     });
   }


### PR DESCRIPTION
Hi!
Thank you for your work! This library helps our product very much :)

This fix aims to handle empty result as an error to make use of https://github.com/i18next/i18next-chained-backend
Since the api doesn't return http status, the code below doesn't work. ( XHR never be called... )

```
import i18next from 'i18next';
import Backend from 'i18next-chained-backend';
import Locize from 'i18next-locize-backend'; // load from service
import XHR from 'i18next-xhr-backend'; // have a own xhr fallback

i18next
  .use(Backend)
  .init({
    backend: {
      backends: [
        Locize,  // primary
        XHR      // fallback
      ],
      backendOptions: [{
        projectId: 'myLocizeProjectId'
      }, {
        loadPath: '/locales/{{lng}}/{{ns}}.json' // xhr load path for my own fallback
      }]
    }
  });
```
 
How do you think about this?
Thanks!