### PR TITLE
fix(react-native): package has been ignored warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "type": "module",
   "main": "./cjs/index.js",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "require": "./cjs/index.js",
       "default": "./lib/index.js"


### PR DESCRIPTION
Fixes https://github.com/locize/i18next-locize-backend/issues/325