### PR TITLE
referenceLanguage option was incorrect -> referenceLng

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace I18NextLocizeBackend {
     /**
      * the reference (source) language of your project (default "en")
      */
-    referenceLanguage?: string;
+    referenceLng?: string;
     /**
      * the version of translations to load
      */


### PR DESCRIPTION
Option seems to be misnamed in the typing: https://github.com/locize/i18next-locize-backend/blob/master/lib/index.js#L11

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added