### PR TITLE
chore: add translatedPercentageThreshold info

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ i18next.use(Backend).init(i18nextOptions);
   onSaved: (lng, ns) => { ... },
 
   // can be used to reload resources in a specific interval (useful in server environments)
-  reloadInterval: typeof window !== 'undefined' ? false : 60 * 60 * 1000
+  reloadInterval: typeof window !== 'undefined' ? false : 60 * 60 * 1000,
+  
+  // define the threshold for languages to be added to supportedLngs (eg: 1 = 100% translated, 0.9 = 90% translated [default]).
+  translatedPercentageThreshold: 0.8
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

The `translatedPercentageThreshold` is not so obvious to find out and, in my case was dropping languages I was testing due the high value setup by default

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [x] documentation is changed or added