### PR TITLE
Limit the number of preflight requests by CORS

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -29,13 +29,17 @@ if (typeof fetchApi !== 'function') fetchApi = undefined
 
 // fetch api stuff
 const requestWithFetch = (options, url, payload, callback) => {
+  const headers = {}
+  if (options.authorize && options.apiKey) {
+    headers.Authorization = options.apiKey
+  }
+  if (payload || options.setContentTypeJSON) {
+    headers['Content-Type'] = 'application/json'
+  }
   fetchApi(url, {
     method: payload ? 'POST' : 'GET',
     body: payload ? JSON.stringify(payload) : undefined,
-    headers: {
-      Authorization: options.authorize && options.apiKey ? options.apiKey : undefined,
-      'Content-Type': 'application/json'
-    }
+    headers
   }).then((response) => {
     const resourceNotExisting = response.headers && response.headers.get('x-cache') === 'Error from cloudfront'
     if (!response.ok) return callback(response.statusText || 'Error', { status: response.status, resourceNotExisting })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
When using the fetch api, 2 headers are added which are restricted by CORS.
1- `Authorization` is not an allowed header
2- `Content-Type` cannot be `application/json`.
source: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests

At the moment, those two are sent when using fetchApi, but not when using XmlHttpRequest.
This causes unwanted OPTIONS/preflight requests for every translation file.

OPTIONS request:
![image](https://user-images.githubusercontent.com/1634993/153282796-652da542-375f-4c54-9c4d-d05ee7f0ff2d.png)

GET request:
![image](https://user-images.githubusercontent.com/1634993/153282875-0db83891-ebb7-4937-81de-a4320fe12cdf.png)

1- Looks like the fetch api will stringify `undefined` when passed in a header field. The field can be omitted when it doesn't have a value instead.
2- ContentType doesn't need to be specified for GET requests since `response.text()` is being used (will the server return `application/json` anyways in that case?).

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added