### PR TITLE
security: guard the getLastOfPath/setPath/pushPath walker against prototype pollution

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,25 +81,30 @@ function getLastOfPath (object, path, Empty) {
     if (!object) return {}
 
     const key = cleanKey(stack.shift())
+    // guard against prototype pollution — refuse to traverse __proto__,
+    // constructor or prototype segments. Returning an empty result lets
+    // callers drop the write silently rather than walking into Object.prototype.
+    if (UNSAFE_KEYS.indexOf(key) > -1) return {}
     if (!object[key] && Empty) object[key] = new Empty()
     object = object[key]
   }
 
   if (!object) return {}
-  return {
-    obj: object,
-    k: cleanKey(stack.shift())
-  }
+  const k = cleanKey(stack.shift())
+  if (UNSAFE_KEYS.indexOf(k) > -1) return {}
+  return { obj: object, k }
 }
 
 export function setPath (object, path, newValue) {
   const { obj, k } = getLastOfPath(object, path, Object)
+  if (obj === undefined) return // unsafe path — drop silently
 
   obj[k] = newValue
 }
 
 export function pushPath (object, path, newValue, concat) {
   const { obj, k } = getLastOfPath(object, path, Object)
+  if (obj === undefined) return // unsafe path — drop silently
 
   obj[k] = obj[k] || []
   if (concat) obj[k] = obj[k].concat(newValue)

--- a/test/security.spec.js
+++ b/test/security.spec.js
@@ -4,7 +4,10 @@ import {
   interpolateUrl,
   isSafeUrlSegment,
   sanitizeLogValue,
-  redactUrlCredentials
+  redactUrlCredentials,
+  setPath,
+  pushPath,
+  getPath
 } from '../lib/utils.js'
 
 // Security tests for the 9.0.2 hardening.
@@ -117,6 +120,58 @@ describe('security', () => {
         .to.equal('https://api.locize.app/p/v/en/x')
       expect(redactUrlCredentials('https://api.locize.app/p/v/en/x'))
         .to.equal('https://api.locize.app/p/v/en/x')
+    })
+  })
+
+  describe('setPath / pushPath prototype-pollution guard', () => {
+    // getLastOfPath() is the shared object walker used by the missing-key
+    // persistence path (queue() -> pushPath, write() -> getPath/setPath). It
+    // splits a dotted path and walks it; without a guard an unsafe segment
+    // such as __proto__ walks straight into Object.prototype. Same walker /
+    // same fix as i18next-fs-backend 2.6.6 (GHSA-2933-q333-qg83).
+
+    afterEach(() => {
+      delete Object.prototype.polluted
+      delete Object.prototype.isAdmin
+    })
+
+    it('setPath drops a write whose path traverses __proto__ (string path)', () => {
+      const data = {}
+      setPath(data, '__proto__.polluted', 'PWNED')
+      expect(({}).polluted).to.be(undefined)
+      expect(Object.prototype.polluted).to.be(undefined)
+      expect(data).to.eql({})
+    })
+
+    it('setPath drops a write whose path traverses __proto__ / constructor / prototype (array path)', () => {
+      setPath({}, ['__proto__', 'polluted'], 'PWNED')
+      setPath({}, ['constructor', 'prototype', 'polluted'], 'PWNED')
+      setPath({}, ['prototype', 'polluted'], 'PWNED')
+      expect(({}).polluted).to.be(undefined)
+      expect(Object.prototype.polluted).to.be(undefined)
+    })
+
+    it('setPath drops a write whose final segment is an unsafe key', () => {
+      setPath({}, ['en', 'translation', '__proto__'], { isAdmin: true })
+      expect(({}).isAdmin).to.be(undefined)
+      expect(Object.prototype.isAdmin).to.be(undefined)
+    })
+
+    it('pushPath drops a write whose path traverses an unsafe key', () => {
+      pushPath({}, ['__proto__', 'polluted'], 'PWNED')
+      expect(({}).polluted).to.be(undefined)
+      expect(Object.prototype.polluted).to.be(undefined)
+    })
+
+    it('still writes and reads legitimate nested paths', () => {
+      const data = {}
+      setPath(data, ['en', 'translation', 'greeting'], 'hello')
+      expect(data.en.translation.greeting).to.equal('hello')
+      expect(getPath(data, ['en', 'translation', 'greeting'])).to.equal('hello')
+
+      const queue = {}
+      pushPath(queue, ['en', 'common'], { key: 'title' })
+      expect(queue.en.common).to.eql([{ key: 'title' }])
     })
   })
 })


### PR DESCRIPTION
`i18next-fs-backend` 2.6.6 hardened its `getLastOfPath` / `setPath` / `pushPath` walker against prototype pollution ([GHSA-2933-q333-qg83](https://github.com/i18next/i18next-fs-backend/security/advisories/GHSA-2933-q333-qg83)): an unsafe path segment such as `__proto__` was walked straight into `Object.prototype`.

This package carries the same walker in `lib/utils.js`. The 9.0.2 security pass already added the `UNSAFE_KEYS` guard to `defaults()`, `interpolate()`, `interpolateUrl()` and `isSafeUrlSegment()`, but `getLastOfPath` / `setPath` / `pushPath` were left without it, so the walker is still pollutable at the function level:

```js
setPath({}, '__proto__.polluted', 'PWNED')
;({}).polluted // before: 'PWNED'  (Object.prototype polluted)
```

The walker is reached from the missing-key persistence path: `create()`/`update()` -> `queue()` -> `pushPath(this.queuedWrites, [lng, namespace], …)`, and `write()` -> `getPath`/`setPath(this.queuedWrites, [lng, namespace], …)`. The missing key itself is stored as a value and POSTed to locize, so the fs-backend attack shape (the key being split and walked) does not transfer directly here; the segment that reaches the walker is `namespace`, e.g. `t('__proto__:x')` with the default `nsSeparator` and `saveMissing` enabled. Impact is therefore lower than the fs-backend advisory, so I have framed this as a defence-in-depth parity fix rather than a like-for-like vuln.

The change mirrors the fs-backend 2.6.6 fix exactly: `getLastOfPath` refuses to descend through `__proto__` / `constructor` / `prototype` and returns an empty result, and `setPath` / `pushPath` drop the write when the path is unsafe. Legitimate dotted keys behave as before:

```js
setPath({}, '__proto__.polluted', 'PWNED')
;({}).polluted // after: undefined
```

`test/security.spec.js` gets a matching block. The full suite stays green (lint + build + fetch + xmlhttpreq + typescript). Only `lib/utils.js` and the test changed; I left the built bundle for the release step, same as the fs-backend fix commit.
